### PR TITLE
Update to Swift 2.2

### DIFF
--- a/ReplaceAnimation/MailButton.swift
+++ b/ReplaceAnimation/MailButton.swift
@@ -108,11 +108,11 @@ class MailButton: UIButton {
   }
   
   private func addTargets() {
-    self.addTarget(self, action: "touchDown:", forControlEvents: UIControlEvents.TouchDown)
-    self.addTarget(self, action: "touchUpInside:", forControlEvents: UIControlEvents.TouchUpInside)
-    self.addTarget(self, action: "touchDragExit:", forControlEvents: UIControlEvents.TouchDragExit)
-    self.addTarget(self, action: "touchDragEnter:", forControlEvents: UIControlEvents.TouchDragEnter)
-    self.addTarget(self, action: "touchCancel:", forControlEvents: UIControlEvents.TouchCancel)
+    self.addTarget(self, action: #selector(MailButton.touchDown(_:)), forControlEvents: UIControlEvents.TouchDown)
+    self.addTarget(self, action: #selector(MailButton.touchUpInside(_:)), forControlEvents: UIControlEvents.TouchUpInside)
+    self.addTarget(self, action: #selector(MailButton.touchDragExit(_:)), forControlEvents: UIControlEvents.TouchDragExit)
+    self.addTarget(self, action: #selector(MailButton.touchDragEnter(_:)), forControlEvents: UIControlEvents.TouchDragEnter)
+    self.addTarget(self, action: #selector(MailButton.touchCancel(_:)), forControlEvents: UIControlEvents.TouchCancel)
   }
   
   internal func touchDown(sender: MailButton) {

--- a/ReplaceAnimation/ViewController.swift
+++ b/ReplaceAnimation/ViewController.swift
@@ -67,7 +67,7 @@ class ViewController: UICollectionViewController {
       layout.parallaxHeaderAlwaysOnTop = true
       layout.disableStickyHeaders = true
       self.collectionView?.collectionViewLayout = layout
-      self.collectionView?.panGestureRecognizer.addTarget(self, action: Selector("handlePan:"))
+      self.collectionView?.panGestureRecognizer.addTarget(self, action: #selector(ViewController.handlePan(_:)))
     }
     
     threshold = -floor(0.3 * screenBounds.width)


### PR DESCRIPTION
This commit fixes:
- Warnings: "Use of string literal for Objective-C selectors is deprecated; use '#selector' instead"
